### PR TITLE
Fixed issue: app got crashed when reset adapter's data during on going scrolling event of recyclerview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+/.idea/

--- a/carouselrecyclerview/src/main/java/com/jackandphantom/carouselrecyclerview/CarouselLayoutManager.kt
+++ b/carouselrecyclerview/src/main/java/com/jackandphantom/carouselrecyclerview/CarouselLayoutManager.kt
@@ -632,6 +632,8 @@ class CarouselLayoutManager constructor(
      * calls the interface callback
      */
     private fun onSelectedCallback() {
+        if (itemCount == 0) return
+
         //Some time interval distance is returns 0 that makes [ArithmeticException]
         val intervalDistance = getIntervalDistance()
         if (intervalDistance == 0) return


### PR DESCRIPTION
- Fixed issue: app got crashed when resetting the adapter's data during the ongoing scrolling event of recyclerview
- Added .idea file to gitignore